### PR TITLE
fix: replace shell-quote parse() with split() in extractArgs

### DIFF
--- a/ide/deploy/deploy.js
+++ b/ide/deploy/deploy.js
@@ -102,11 +102,9 @@ async function extractArgs(files) {
 
         // Split the argument line into individual arguments
         if (argLine) {
-          const parsed = parse(argLine);
-          for (const arg of parsed) {
-            if (typeof arg === 'string') {
-              res.push(arg);
-            }
+          const parts = argLine.split(/\s+/);
+          for (const part of parts) {
+            if (part) res.push(part);
           }
         }
       }


### PR DESCRIPTION
## Summary

- `parse()` from `shell-quote` expands `$VAR` references to empty strings before `expandEnv()` can process them
- Action parameters like `#--param S3_HOST $S3_HOST` lose their values during deployment
- Replace `parse()` with `split(/\s+/)` in `extractArgs()` only
- `exec()` is not affected because `expandEnv()` resolves variables before `parse()` sees them

## Bug details

```
Input:             "--param S3_HOST $S3_HOST"
parse() result:    ["--param", "S3_HOST", ""]          ← BUG: $S3_HOST expanded to ""
split() result:    ["--param", "S3_HOST", "$S3_HOST"]  ← OK: preserved for expandEnv()
```

## Test plan

- [x] Tested end-to-end on k3s cluster (lorenzo1.hz.nuvolaris.dev)
- [x] Cotemar pipeline (6 stages: Tika + LLM + S3 + BPMN/SVG/PDF) with custom runtime
- [x] Verified on 2 namespaces (cotemar, cotemardev)
- [x] S3 params (`S3_HOST`, `S3_PORT`, etc.) correctly passed to action after fix
- [x] Running in production for 3 weeks without issues

Related: nuvolaris/projects#409